### PR TITLE
Fixed small typo in fallout-4.md

### DIFF
--- a/src/game-support/fallout-4.md
+++ b/src/game-support/fallout-4.md
@@ -8,8 +8,8 @@ The recent Next Gen update now allows the game to launch with audio enabled.
 ## Voices and Music Fix
 
 - Add all of the following libraries to the `Wine Configuration` panel.
-  - `x3audio1_6`
-  - `x3audio1_7`
+  - `x3daudio1_6`
+  - `x3daudio1_7`
   - `xaudio2_6`
   - `xaudio2_7`
 - Adjust your output speaker format in Audio MIDI Setup to reduce popping audio i.e. `48,000hz`


### PR DESCRIPTION
Changed x3audio1_6 and x3audio1_7 to x3daudio1_6 and x3daudio1_7 as that is their name in the Wine configuration window (see in screenshot below).

![Screenshot 2024-05-14 at 12 00 06](https://github.com/Whisky-App/whisky-book/assets/33729366/16e987fc-ac8c-4019-8421-5070ca5376b8)