### PR TITLE
Create run-locally.sh to automate running locally, fix last commit, add name to Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+name: Check linting
+
 on:
   push:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -15,14 +15,11 @@ Documentation for Whisky.
 3. Install [rust](https://www.rust-lang.org/tools/install)
 4. Install mdbook and the required preprocessors
    ```
-   cargo install mdbook
-   cargo install mdbook-alerts
-   cargo install mdbook-template
-   cargo install mdbook-last-changed
+   cargo install mdbook mdbook-alerts mdbook-template mdbook-last-changed
    ```
-5. Install [Node.js](https://nodejs.org/en/download/).
-   You can also install it through [Homebrew](https://brew.sh/) with `brew install node`.
-6. You can preview changes to the book with `mdbook serve --open`
+   > Alternatively, you can run `./scripts/run-locally.sh -i`, which installs the preprocessors and opens the wiki on a local webpage.
+5. Run `./scripts/run-locally.sh` to open the wiki on a local webpage.
+   > Alternatively, you can run `mdbook serve --open`.
 
 ### Adding Game Pages:
 0. Standards to uphold:
@@ -72,12 +69,11 @@ Documentation for Whisky.
    
    ```
    <img width="815" alt="Screenshot 2024-04-16 at 10 06 11 PM" src="https://github.com/Whisky-App/whisky-book/assets/161992562/d7d61b1a-5d02-4961-8ff5-b953c2a2fbe1">  
-3. Run the `generate` script with `./scripts/generate.mjs` to update `SUMMARY.md`.
-   This will also make the game appear in the sidebar of the book.
+3. Run `./scripts/run-locally.sh` to generate the sidebar and ensure formatting. 
+   > Alternatively, you can run `./scripts/generate.mjs` and `./scripts/lint.mjs` to do these without opening the book again.
 4. Create a pull request detailing the changes you made. Ensure that it's consise, yet readable and coherent.
    - You will need to create a fork of `whisky-book` and push your changes there before creating a PR. Once you've done that, then you can submit a PR to merge your fork with `main`.
-5. Run `./scripts/lint.mjs` to ensure that your changes are properly formatted.
-6. Sit back, wait for PR reviews, and make changes as necessary.
+5. Sit back, wait for PR reviews, and make changes as necessary.
 
 Have any questions about this process or anything Whisky-related? Stop by the [Discord](https://discord.gg/CsqAfs9CnM) and ask us a question! We're more than happy to help.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation for Whisky.
    cargo install mdbook mdbook-alerts mdbook-template mdbook-last-changed
    ```
    > Alternatively, you can run `./scripts/run-locally.sh -i`, which installs the preprocessors and opens the wiki on a local webpage.
-5. Run `./scripts/run-locally.sh` to open the wiki on a local webpage.
+5. Run `./scripts/run-locally.sh` to open the wiki on a local webpage. This script MUST be ran from the root `whisky-book` directory or it will not work.
    > Alternatively, you can run `mdbook serve --open`.
 
 ### Adding Game Pages:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Documentation for Whisky.
    cd whisky-book
    ```
 3. Install [rust](https://www.rust-lang.org/tools/install)
+   You can also install it through [Homebrew](https://brew.sh/) with `brew install rust`.
 4. Install [Node.js](https://nodejs.org/en/download/).
    You can also install it through [Homebrew](https://brew.sh/) with `brew install node`.
 5. Install mdbook and the required preprocessors

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ Documentation for Whisky.
    cd whisky-book
    ```
 3. Install [rust](https://www.rust-lang.org/tools/install)
-4. Install mdbook and the required preprocessors
+4. Install [Node.js](https://nodejs.org/en/download/).
+   You can also install it through [Homebrew](https://brew.sh/) with `brew install node`.
+5. Install mdbook and the required preprocessors
    ```
    cargo install mdbook mdbook-alerts mdbook-template mdbook-last-changed
    ```
    > Alternatively, you can run `./scripts/run-locally.sh -i`, which installs the preprocessors and opens the wiki on a local webpage.
-5. Run `./scripts/run-locally.sh` to open the wiki on a local webpage. This script MUST be ran from the root `whisky-book` directory or it will not work.
+6. Run `./scripts/run-locally.sh` to open the wiki on a local webpage. This script MUST be ran from the root `whisky-book` directory or it will not work.
    > Alternatively, you can run `mdbook serve --open`.
 
 ### Adding Game Pages:

--- a/book.toml
+++ b/book.toml
@@ -16,7 +16,7 @@ renderer = ["html"]
 [output.html]
 default-theme = "whisky"
 preferred-dark-theme = "whisky"
-git-repository-url = "https://github.com/Whisky-App/Whisky"
+git-repository-url = "https://github.com/Whisky-App/whisky-book"
 git-repository-icon = "fa-github"
 edit-url-template = "https://github.com/Whisky-App/whisky-book/edit/main/{path}"
 input-404 = "not-found.md"

--- a/scripts/run-locally.sh
+++ b/scripts/run-locally.sh
@@ -1,0 +1,24 @@
+BASENAME=`basename $PWD`
+
+if [[ $BASENAME == "whisky-book" ]]; then
+
+    # get args
+    ARGS=$1
+
+    if [[ $ARGS == "-i" ]]; then
+        # install preprocessors
+        cargo install mdbook mdbook-alerts mdbook-template mdbook-last-changed
+    fi
+
+    # generate sidebar
+    ./scripts/generate.mjs
+
+    # check linting
+    ./scripts/lint.mjs
+
+    # open book
+    mdbook serve --open
+
+else
+    echo "Improper directory! Please execute this script from the root of the whisky-book directory."
+fi


### PR DESCRIPTION
Enables users to run locally with 1 script. Script MUST be ran from `.../whisky-book`, or will not work. Script can be ran either `./scripts/run-locally.sh` to generate the sidebar, check linting, and open the page, or `./scripts/run-locally.sh -i` to install the cargo dependencies, and then do the same thing as `./scripts/run-locally.sh`.

Also fixes the repository that `mdbook-last-changed` was pointing to, as it was previously the `Whisky` repo.

Add name `Check Linting` to linting workflow