### PR TITLE
Add GrandChase to supported games

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -64,6 +64,7 @@
   - [Friends vs Friends](./game-support/friends-vs-friends.md)
   - [Granblue Fantasy: Versus](./game-support/gbfvs.md)
   - [Guilty Gear -Strive-](./game-support/ggst.md)
+  - [GrandChase](./game-support/grandchase.md)
   - [GreedFall](./game-support/greedfall.md)
   - [Grand Theft Auto V](./game-support/gta-5.md)
   - [Guild Wars 2](./game-support/gw2.md)

--- a/src/game-support/grandchase.md
+++ b/src/game-support/grandchase.md
@@ -1,0 +1,6 @@
+# GrandChase
+<!-- script:Aliases [] -->
+
+{{#template ../templates/rating.md status=Platinum installs=Yes opens=Yes}}
+
+{{#template ../templates/steam.md id=985810}}


### PR DESCRIPTION
Tested on Whisky version 2.3.2 (current), the game runs flawlessly from Steam - no setup needed after installation.

![image](https://github.com/user-attachments/assets/b5910092-9796-4791-bf20-aa99b813ea07)
