### PR TITLE
Persona 4 Golden: Add warning about quicksave loss

### DIFF
--- a/src/game-support/p4g.md
+++ b/src/game-support/p4g.md
@@ -7,4 +7,7 @@
 
 Game crashes when you enter a dungeon.
 
+> [!WARNING]
+> Loading the game when you are in a dungeon, **at all**, will cause your game to crash. If you attempt to load into a dungeon from the "continue" option, you **will** lose your quick save data.
+
 {{#template ../templates/steam.md id=1113000}}


### PR DESCRIPTION
Short addition adding a warning note about losing quicksave data.