### PR TITLE
Fix GTA SA and Genshin Impact links

### DIFF
--- a/src/game-support/genshin-impact.md
+++ b/src/game-support/genshin-impact.md
@@ -19,4 +19,4 @@ Natlan has some texture issues where parts of the ground appear rainbow colored.
 
 ### Verification Issues
 Some users report being unable to view the verification puzzle.  
-Fix detailed here: [https://github.com/Whisky-App/Whisky/issues/858#issuecomment-1987155593](https://github.com/Whisky-App/Whisky/issues/858#issuecomment-1987155593)
+Fix detailed [here.](https://github.com/Whisky-App/Whisky/issues/858#issuecomment-1987155593)

--- a/src/game-support/gta-sa.md
+++ b/src/game-support/gta-sa.md
@@ -19,4 +19,4 @@ The game crashes immediately during load without error message and is therefore 
   - If not on, turn `DXVK` on.
 - Download and install the game from the Rockstar Games Launcher as usual.
 
-{{#template ../templates/steam.md id=12120}}
+Here is the [Grand Theft Auto: San Andreas Steam link](https://store.steampowered.com/app/12120/Grand_Theft_Auto_San_Andreas/) as the preview won't be loaded for an unavailable game.


### PR DESCRIPTION
Fix links that are wrongly formatted (Genshin) and broken (GTA SA Steam). I approved and merged those PRs with those issues. I missed them basically.