### PR TITLE
Added support for Age of Empires II: Definitive Edition on Steam

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -11,6 +11,7 @@
   <!-- script:Generate Start -->
   - [Assassin's Creed: Director's Cut Edition](./game-support/ac-directors-cut.md)
   - [Among Us](./game-support/among-us.md)
+  - [Age of Empires II: Definitive Edition](./game-support/aoe2_definitive_edition.md)
   - [Armored Core VI: Fires of Rubicon](./game-support/armored-core-6.md)
   - [Battle Brothers](./game-support/battle-brothers.md)
   - [BeamNG.Drive](./game-support/beamng-drive.md)

--- a/src/game-support/aoe2_definitive_edition.md
+++ b/src/game-support/aoe2_definitive_edition.md
@@ -1,0 +1,14 @@
+# Age of Empires II: Definitive Edition
+<!-- script:Aliases [
+    "Age of Empires II: Definitive Edition"
+] -->
+
+{{#template ../templates/rating.md status=Bronze installs=Yes opens=Yes}}
+
+> [!NOTE]
+> Other than the start menu, Age of Empires II: Definitive Edition runs fine through Whisky when in a game, and if the player is familiar with the controls beforehand.  
+
+> [!WARNING]
+> The start-up menu UI does not display text on any buttons. Unless you know already how to navigate the menu, this can be very frustrating. 
+
+{{#template ../templates/steam.md id=813780}}


### PR DESCRIPTION
<!--This template is based on https://github.com/macports/macports-ports/blob/master/.github/PULL_REQUEST_TEMPLATE.md, thanks Gcenx!-->
# Description
Adds documentation for support for [Age of Empires II: Definitive Edition](https://store.steampowered.com/app/813780/Age_of_Empires_II_Definitive_Edition/), one of the most popular strategy games ever. Currently at Bronze, the game is technically playable without any issues, but the startup menu UI is broken. 
<!--Note: it is best to make pull requests from a branch rather than from main-->

## Type(s) <!-- (delete not applicable items) -->

- [x] Game page addition
- [ ] Game page modification
- [ ] Other wiki edit

## Verification <!-- (delete not applicable items) -->
Have you

- [x] Followed the [contribution guidelines?](https://github.com/Whisky-App/whisky-book?tab=readme-ov-file#please-read-all-steps-before-contributing)
- [x] Ran `./scripts/generate.mjs`?
- [x] Ran `./scripts/lint.mjs`?
- [x] Checked spelling and grammar?
- [x] (If applicable) Provided documentation for a game not working? (i.e. detailing what happens when the game doesn't work?)
- [x] (If applicable) Ensured the linked Steam ID is the correct one for your game addition? 
